### PR TITLE
Fix Phase 2 bugs: model selection, validation, send_text, proactive messaging

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -1,8 +1,9 @@
 """Coppermind Capture API — store sparks from anywhere."""
 
+import base64 as b64_module
 import hashlib
 import os
-from typing import Optional
+from typing import List, Optional
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -254,10 +255,19 @@ def health():
 # ── Hermes Messaging Endpoint ───────────────────────────────
 
 
+ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
+
+
+class ImageData(BaseModel):
+    media_type: str
+    data: str
+
+
 class MessageRequest(BaseModel):
     content: str
     channel: str = "imessage"
     model_override: Optional[str] = None
+    images: Optional[List[ImageData]] = None
 
 
 class MessageResponse(BaseModel):
@@ -270,10 +280,55 @@ class MessageResponse(BaseModel):
 @app.post("/message", response_model=MessageResponse)
 def handle_message(req: MessageRequest, x_api_key: str = Header(default=None)):
     """Process an incoming message through Hermes and return a reply."""
-    logger.info(f"Hermes message: channel={req.channel} content={req.content[:80]}...")
+    logger.info(f"Hermes message: channel={req.channel} content={req.content[:80]}... images={len(req.images) if req.images else 0}")
     verify_key(x_api_key)
 
+    # Validate images if present
+    images = None
+    if req.images:
+        if len(req.images) > 5:
+            raise HTTPException(status_code=400, detail="Maximum 5 images per message")
+        validated = []
+        for img in req.images:
+            if img.media_type not in ALLOWED_IMAGE_TYPES:
+                raise HTTPException(status_code=400, detail=f"Unsupported image type: {img.media_type}. Allowed: {ALLOWED_IMAGE_TYPES}")
+            if len(img.data) > 5 * 1024 * 1024:
+                raise HTTPException(status_code=400, detail="Image base64 data exceeds 5MB limit")
+            try:
+                b64_module.b64decode(img.data, validate=True)
+            except Exception:
+                raise HTTPException(status_code=400, detail="Invalid base64 image data")
+            validated.append({"media_type": img.media_type, "data": img.data})
+        images = validated
+
     from hermes import process_message
-    result = process_message(req.content, req.channel, req.model_override, mem)
+    result = process_message(req.content, req.channel, req.model_override, mem, images=images)
 
     return MessageResponse(**result)
+
+
+SEND_ALLOWED_RECIPIENTS = {"coppermindvolacci@icloud.com"}
+
+
+class SendRequest(BaseModel):
+    recipient: str
+    text: str
+    source: str = "api"
+
+
+@app.post("/send")
+def send_message(req: SendRequest, x_api_key: str = Header(default=None)):
+    """Send a proactive iMessage to Ben via the Mac relay."""
+    logger.info(f"Proactive send: recipient={req.recipient} source={req.source} text={req.text[:80]}...")
+    verify_key(x_api_key)
+
+    if req.recipient not in SEND_ALLOWED_RECIPIENTS:
+        raise HTTPException(status_code=403, detail=f"Recipient not in allowlist")
+
+    from hermes import send_imessage_proactive
+    success = send_imessage_proactive(req.recipient, req.text)
+
+    if not success:
+        raise HTTPException(status_code=502, detail="Failed to send iMessage via Mac relay")
+
+    return {"sent": True, "recipient": req.recipient}

--- a/evaluator.py
+++ b/evaluator.py
@@ -735,6 +735,44 @@ def _resolve_recipient_email(name: str, mem) -> Optional[dict]:
     return None
 
 
+def _resolve_recipient_phone(name: str, mem) -> Optional[dict]:
+    """Run a focused agent loop to resolve a name to a phone number or iMessage address."""
+    system_prompt = (
+        "You are resolving a contact's phone number or iMessage address. Use the available tools to "
+        "find the best phone number for the given person. When you have found it, "
+        'respond with ONLY a JSON object: {"phone": "+15551234567", "display_name": "Full Name"}. '
+        "If the contact has an iMessage email address, that works too. "
+        'If you cannot find a phone, respond with: {"phone": null, "display_name": null}'
+    )
+
+    user_message = f"Find the phone number or iMessage address for: {name}"
+    messages = [{"role": "user", "content": user_message}]
+
+    tools = ENRICHMENT_TOOLS_ANTHROPIC + [RESOLVE_CONTACT_TOOL_ANTHROPIC]
+
+    tool_executors = {
+        "search_memory": lambda args: _tool_search_memory(args["query"], mem),
+        "search_contacts": lambda args: _tool_search_contacts(args["query"]),
+        "search_web": lambda args: _tool_search_web(args["query"]),
+        "resolve_contact": lambda args: _tool_resolve_contact(
+            args["name"], args.get("contact_type", "phone"), mem
+        ),
+    }
+
+    try:
+        result = _run_agent_loop_haiku(
+            system_prompt, messages, tools, tool_executors,
+        )
+        if result:
+            parsed = _extract_json(result)
+            if parsed and parsed.get("phone"):
+                return parsed
+    except Exception as e:
+        logger.warning(f"Phone resolution failed: {e}")
+
+    return None
+
+
 def _send_email_via_mac(to_address: str, to_name: str, subject: str, body: str) -> bool:
     """SSH to ben.local and send an email via Mail.app helper script.
 
@@ -775,6 +813,48 @@ def _send_email_via_mac(to_address: str, to_name: str, subject: str, body: str) 
         return False
     except Exception as e:
         logger.warning(f"SSH email failed: {e}")
+        return False
+
+
+# SSH target + script for iMessage sending
+SEND_IMESSAGE_SCRIPT = os.environ.get("SEND_IMESSAGE_SCRIPT",
+                                       "/Users/benfinklea/bin/send_imessage.py")
+
+
+def _send_text_via_mac(recipient: str, text: str) -> bool:
+    """SSH to ben.local and send an iMessage via send_imessage.py."""
+    payload = {
+        "recipient": recipient,
+        "text": text,
+    }
+    json_bytes = json.dumps(payload).encode("utf-8")
+
+    try:
+        result = subprocess.run(
+            [
+                "ssh",
+                "-o", "ConnectTimeout=5",
+                "-o", "ServerAliveInterval=5",
+                "-o", "ServerAliveCountMax=2",
+                REMINDER_SSH_HOST,
+                "python3", SEND_IMESSAGE_SCRIPT,
+            ],
+            input=json_bytes,
+            capture_output=True,
+            timeout=15,
+        )
+        if result.returncode == 0:
+            logger.info(f"iMessage sent to {recipient}: {text[:80]}...")
+            return True
+        else:
+            stderr = result.stderr.decode("utf-8", errors="replace")
+            logger.warning(f"iMessage script failed: {stderr}")
+            return False
+    except subprocess.TimeoutExpired:
+        logger.warning("SSH iMessage timed out (Mac may be asleep)")
+        return False
+    except Exception as e:
+        logger.warning(f"SSH iMessage failed: {e}")
         return False
 
 
@@ -869,6 +949,84 @@ def _compose_and_send_email(content: str, classification, mem, learning_id: str)
     else:
         _update_metadata(mem, learning_id, {"action_status": "confirm_error"})
         logger.warning(f"email_confirm_error: id={learning_id} result={result}")
+
+
+def _compose_and_send_text(content: str, classification, mem, learning_id: str) -> None:
+    """Orchestrate the full text message (iMessage) action flow."""
+    from confirmation import confirm_action
+
+    recipient_name = classification.action_recipient
+    action_message = classification.action_message or content
+
+    _update_metadata(mem, learning_id, {"action_status": "resolving_contact"})
+    contact = _resolve_recipient_phone(recipient_name, mem)
+
+    if not contact or not contact.get("phone"):
+        logger.warning(f"Could not resolve phone for '{recipient_name}'")
+        _update_metadata(mem, learning_id, {
+            "action_status": "contact_not_found",
+            "action_recipient": recipient_name,
+        })
+        return
+
+    phone_or_email = contact["phone"]
+    display_name = contact.get("display_name", recipient_name)
+
+    _update_metadata(mem, learning_id, {
+        "action_status": "composing",
+        "action_resolved_phone": phone_or_email,
+        "action_resolved_name": display_name,
+    })
+
+    compose_prompt = (
+        f"Compose a brief text message from Ben to {display_name}.\n"
+        f"The message to convey: {action_message}\n"
+        f"Original voice transcript: \"{content}\"\n\n"
+        f'Respond with ONLY a JSON object: {{"text": "the message"}}\n'
+        f"Keep it short and natural, like a real text message. No greeting needed."
+    )
+    raw_text = _call_haiku(compose_prompt)
+    if not raw_text:
+        logger.warning("Text composition failed (Haiku unavailable)")
+        _update_metadata(mem, learning_id, {"action_status": "compose_failed"})
+        return
+
+    # Parse JSON response, fall back to raw text
+    parsed_text = _extract_json(raw_text)
+    if parsed_text and parsed_text.get("text"):
+        text_body = parsed_text["text"]
+    else:
+        text_body = raw_text.strip().strip('"').strip("'")
+
+    _update_metadata(mem, learning_id, {
+        "action_status": "confirming",
+        "action_message_body": text_body,
+    })
+
+    confirmation_details = f"To: {display_name} ({phone_or_email})\n\n{text_body}"
+    result = confirm_action(
+        summary=f"Send text to {display_name}?",
+        details=confirmation_details,
+    )
+
+    if result == "approved":
+        _update_metadata(mem, learning_id, {"action_status": "sending"})
+        sent = _send_text_via_mac(phone_or_email, text_body)
+        if sent:
+            _update_metadata(mem, learning_id, {"action_status": "sent"})
+            logger.info(f"text_sent: id={learning_id} to={phone_or_email}")
+        else:
+            _update_metadata(mem, learning_id, {"action_status": "send_failed"})
+            logger.warning(f"text_send_failed: id={learning_id}")
+    elif result == "rejected":
+        _update_metadata(mem, learning_id, {"action_status": "cancelled"})
+        logger.info(f"text_cancelled: id={learning_id}")
+    elif result == "timeout":
+        _update_metadata(mem, learning_id, {"action_status": "timeout"})
+        logger.info(f"text_timeout: id={learning_id}")
+    else:
+        _update_metadata(mem, learning_id, {"action_status": "confirm_error"})
+        logger.warning(f"text_confirm_error: id={learning_id} result={result}")
 
 
 def _run_agent_loop_haiku(system_prompt: str, messages: list,
@@ -1254,7 +1412,13 @@ def evaluate_and_update(learning_id: str, content: str, source: str, mem) -> Non
             except Exception as e:
                 logger.warning(f"Email action failed (non-fatal): id={learning_id} error={e}")
                 _update_metadata(mem, learning_id, {"action_status": "error"})
-        elif classification.action_type in ("send_text", "send_slack"):
+        elif classification.action_type == "send_text":
+            try:
+                _compose_and_send_text(content, classification, mem, learning_id)
+            except Exception as e:
+                logger.warning(f"Text action failed (non-fatal): id={learning_id} error={e}")
+                _update_metadata(mem, learning_id, {"action_status": "error"})
+        elif classification.action_type == "send_slack":
             _update_metadata(mem, learning_id, {"action_status": "not_implemented"})
             logger.info(f"action_not_implemented: id={learning_id} type={classification.action_type}")
         # Fall through to reminder creation regardless
@@ -1285,6 +1449,25 @@ def evaluate_and_update(learning_id: str, content: str, source: str, mem) -> Non
                     cur.close()
             except Exception:
                 pass  # Non-fatal — reminder still created
+        elif classification.action_type == "send_text":
+            try:
+                conn = mem.learning.postgres_store._get_conn()
+                cur = conn.cursor()
+                try:
+                    cur.execute(
+                        "SELECT metadata->>'action_status' FROM agent_knowledge WHERE id = %s",
+                        (learning_id,),
+                    )
+                    row = cur.fetchone()
+                    action_status = row[0] if row else None
+                    if action_status == "sent":
+                        reminder_body = f"[TEXT SENT]\n{reminder_body}".strip()
+                    elif action_status in ("cancelled", "timeout"):
+                        reminder_body = f"[TEXT {action_status.upper()} -- action needed]\n{reminder_body}".strip()
+                finally:
+                    cur.close()
+            except Exception:
+                pass
         success = _create_apple_reminder(
             title=classification.task_title,
             context=classification.context,

--- a/hermes.py
+++ b/hermes.py
@@ -6,6 +6,7 @@ assembles memory context, calls Claude, and returns replies.
 
 import logging
 import os
+import json
 import re
 from datetime import datetime, date
 from typing import Optional, Tuple
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 MODELS = {
     "haiku": "claude-haiku-4-5-20251001",
-    "sonnet": "claude-sonnet-4-5-20250514",
+    "sonnet": "claude-sonnet-4-6",
     "opus": "claude-opus-4-6",
 }
 DEFAULT_MODEL = "haiku"
@@ -27,13 +28,18 @@ DEFAULT_MODEL = "haiku"
 # ── Budget config ────────────────────────────────────────────
 
 DAILY_BUDGET_USD = float(os.environ.get("HERMES_DAILY_BUDGET", "5.0"))
+
+# ── Proactive messaging config ───────────────────────────────
+
+PROACTIVE_SSH_HOST = os.environ.get("HERMES_SSH_HOST", "ben-mac")
+PROACTIVE_SEND_SCRIPT = os.environ.get("HERMES_SEND_SCRIPT", "/Users/benfinklea/bin/send_imessage.py")
 REDIS_HOST = os.environ.get("COPPERMIND_REDIS_HOST", "100.64.219.124")
 REDIS_PORT = 6379
 
 # Approximate cost per 1K tokens (input/output) for budget tracking
 MODEL_COSTS = {
     "claude-haiku-4-5-20251001": {"input": 0.001, "output": 0.005},
-    "claude-sonnet-4-5-20250514": {"input": 0.003, "output": 0.015},
+    "claude-sonnet-4-6": {"input": 0.003, "output": 0.015},
     "claude-opus-4-6": {"input": 0.015, "output": 0.075},
 }
 
@@ -72,13 +78,31 @@ def _get_anthropic() -> anthropic.Anthropic:
 # ── Public API ───────────────────────────────────────────────
 
 
-def process_message(content: str, channel: str, model_override: Optional[str], mem) -> dict:
+def process_message(content: str, channel: str, model_override: Optional[str], mem, images: list = None) -> dict:
     """Main entry point: process an incoming message and return a reply.
 
     Returns dict with: reply, model_used, cost_usd, intent
     """
     # 1. Parse model override from message prefix
-    model_key, content = _select_model(content, model_override)
+    model_key, content, model_explicit = _select_model(content, model_override)
+
+    # Auto-upgrade to Sonnet for image messages (only when using default model)
+    if images and model_key == "haiku" and not model_explicit:
+        model_key = "sonnet"
+        logger.info("Auto-upgraded to Sonnet for image message")
+
+    # Handle bare model command with no message text
+    if not content and not images:
+        _store_turn(mem, "user", f"/{model_key}")
+        reply = f"Switched to {model_key}. Send your next message."
+        _store_turn(mem, "assistant", reply)
+        return {
+            "reply": reply,
+            "model_used": model_key,
+            "cost_usd": 0.0,
+            "intent": "model_switch",
+        }
+
     model_id = MODELS[model_key]
 
     # 2. Detect slash commands (handled without Claude)
@@ -112,13 +136,18 @@ def process_message(content: str, channel: str, model_override: Optional[str], m
     system_prompt = _build_system_prompt(context_str, channel)
 
     # 6. Call Claude
-    reply, cost_usd = _call_claude(content, system_prompt, model_id, history)
+    reply, cost_usd = _call_claude(content, system_prompt, model_id, history, images=images)
 
     # 7. Record cost
     _record_cost(cost_usd, model_id)
 
-    # 8. Store both turns
-    _store_turn(mem, "user", content)
+    # 8. Store both turns (without base64 image data)
+    if images:
+        n = len(images)
+        store_content = f"[Sent {n} image{'s' if n > 1 else ''}, no longer visible] {content}" if content else f"[Sent {n} image{'s' if n > 1 else ''}, no longer visible]"
+    else:
+        store_content = content
+    _store_turn(mem, "user", store_content)
     _store_turn(mem, "assistant", reply)
 
     return {
@@ -132,18 +161,19 @@ def process_message(content: str, channel: str, model_override: Optional[str], m
 # ── Internal functions ───────────────────────────────────────
 
 
-def _select_model(content: str, model_override: Optional[str] = None) -> Tuple[str, str]:
-    """Parse /haiku, /sonnet, /opus prefix from message. Returns (model_key, cleaned_content)."""
+def _select_model(content: str, model_override: Optional[str] = None) -> Tuple[str, str, bool]:
+    """Parse /haiku, /sonnet, /opus prefix from message. Returns (model_key, cleaned_content, was_explicit)."""
     if model_override and model_override in MODELS:
-        return model_override, content
+        return model_override, content, True
 
+    lower = content.lower()
     for key in MODELS:
         prefix = f"/{key}"
-        if content.lower().startswith(prefix):
+        if lower == prefix or lower.startswith(prefix + " "):
             cleaned = content[len(prefix):].strip()
-            return key, cleaned if cleaned else content
+            return key, cleaned, True
 
-    return DEFAULT_MODEL, content
+    return DEFAULT_MODEL, content, False
 
 
 def _detect_intent(content: str, mem) -> Tuple[Optional[str], Optional[str]]:
@@ -327,6 +357,9 @@ def _build_system_prompt(context: str, channel: str) -> str:
         "- Use the provided memories to give personalized, contextual answers.\n"
         "- If you don't know something and it's not in the memories, say so.\n"
         "- You can reference things from earlier in the conversation naturally.\n"
+        "- Messages in history prefixed with [Sent N image(s), no longer visible] mean the user previously sent images "
+        "that are no longer visible. If asked about prior images, note you can only see images "
+        "in the current message.\n"
         "- No emojis unless Ben uses them first.\n"
         "- For technical topics, be precise but not verbose.\n"
         f"- Current date: {date.today().isoformat()}\n"
@@ -349,12 +382,33 @@ def _build_system_prompt(context: str, channel: str) -> str:
     return base
 
 
-def _call_claude(message: str, system: str, model: str, history: list) -> Tuple[str, float]:
+def _call_claude(message: str, system: str, model: str, history: list, images: list = None) -> Tuple[str, float]:
     """Call Claude API and return (reply_text, cost_usd)."""
     client = _get_anthropic()
 
     messages = history.copy()
-    messages.append({"role": "user", "content": message})
+
+    # Build content blocks for the user message
+    if images:
+        content_blocks = []
+        for img in images:
+            content_blocks.append({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": img["media_type"],
+                    "data": img["data"],
+                },
+            })
+        # Add text block (default prompt if no text with image)
+        text = message.strip() if message else "What's in this image?"
+        content_blocks.append({"type": "text", "text": text})
+        messages.append({"role": "user", "content": content_blocks})
+    else:
+        messages.append({"role": "user", "content": message})
+
+    # Longer timeout for vision requests
+    timeout = 120.0 if images else 60.0
 
     try:
         response = client.messages.create(
@@ -362,6 +416,7 @@ def _call_claude(message: str, system: str, model: str, history: list) -> Tuple[
             max_tokens=1024,
             system=system,
             messages=messages,
+            timeout=timeout,
         )
 
         reply = response.content[0].text
@@ -435,3 +490,38 @@ def _record_cost(cost_usd: float, model: str):
         r.expire(model_key, 172800)
     except Exception as e:
         logger.warning(f"Failed to record cost: {e}")
+
+
+def send_imessage_proactive(recipient: str, text: str) -> bool:
+    """Send an iMessage proactively by SSH-ing to ben.local and piping to send_imessage.py."""
+    import subprocess
+
+    payload = json.dumps({"recipient": recipient, "text": text})
+
+    try:
+        result = subprocess.run(
+            [
+                "ssh",
+                "-o", "ConnectTimeout=5",
+                "-o", "ServerAliveInterval=5",
+                "-o", "ServerAliveCountMax=2",
+                PROACTIVE_SSH_HOST,
+                "python3", PROACTIVE_SEND_SCRIPT,
+            ],
+            input=payload.encode("utf-8"),
+            capture_output=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            logger.info(f"Proactive iMessage sent to {recipient}: {text[:80]}...")
+            return True
+        else:
+            stderr = result.stderr.decode("utf-8", errors="replace")
+            logger.warning(f"Proactive iMessage failed: {stderr}")
+            return False
+    except subprocess.TimeoutExpired:
+        logger.warning("Proactive iMessage SSH timed out (Mac may be asleep)")
+        return False
+    except Exception as e:
+        logger.warning(f"Proactive iMessage failed: {e}")
+        return False


### PR DESCRIPTION
## Summary
- Fix #1: `/sonnet` with no text now returns empty content + helpful reply instead of raw slash command
- Fix #2: base64 validation added for image data in `/message` endpoint
- Fix #3: reminder body annotated with `[TEXT SENT]`/`[TEXT CANCELLED]` for send_text actions
- Fix #4: text compose prompt uses JSON-structured output (matching email path)
- Fix #5: `send_imessage_proactive` reads SSH host/script from env vars
- Fix #6: model prefix matching requires word boundary (`/haiku` won't match `/haikutown`)
- Fix #7: auto-upgrade to Sonnet only fires for default model, not explicit `/haiku` choice
- Fix #8: system prompt explains `[N image(s)]` convention; storage format clarified

## Root Cause
Multiple issues introduced during Phase 2 image support + proactive messaging implementation.

## Validation
- All 3 files pass syntax check
- Capture service restarted and healthy
- /send endpoint tested successfully
- Image message pipeline tested end-to-end

## Test plan
- [ ] Send `/sonnet` with no text -> get "Switched to sonnet" reply
- [ ] Send `/haikutown` -> message not mangled
- [ ] Send `/haiku` with photo -> stays on haiku (not auto-upgraded)
- [ ] curl /message with invalid base64 -> get 400 error
- [ ] Verify send_text reminder annotation via spark evaluation
- [ ] curl /send -> iMessage arrives

Closes #1, Closes #2, Closes #3, Closes #4, Closes #5, Closes #6, Closes #7, Closes #8

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)