### PR TITLE
Phase 2.5: Hermes enhancements (server-side)

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -3,6 +3,7 @@
 import base64 as b64_module
 import hashlib
 import os
+import time
 from typing import List, Optional
 import sys
 import threading
@@ -75,6 +76,26 @@ class Spark(BaseModel):
 def verify_key(x_api_key: str):
     if not x_api_key or x_api_key != API_KEY:
         raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+def _check_server_rate_limit(r_client, key_prefix: str = "hermes:rate", limit: int = 30, window: int = 60):
+    """Redis sliding window rate limiter. Returns (allowed, retry_after_secs)."""
+    try:
+        import time as _time
+        now = _time.time()
+        bucket = f"{key_prefix}:{int(now // window)}"
+        pipe = r_client.pipeline()
+        pipe.incr(bucket)
+        pipe.expire(bucket, window * 2)
+        results = pipe.execute()
+        count = results[0]
+        if count > limit:
+            retry_after = window - (now % window)
+            return False, int(retry_after) + 1
+        return True, 0
+    except Exception as e:
+        logger.warning(f"Rate limit check failed (allowing): {e}")
+        return True, 0
 
 
 def _compute_content_hash(content: str) -> str:
@@ -282,6 +303,26 @@ def handle_message(req: MessageRequest, x_api_key: str = Header(default=None)):
     """Process an incoming message through Hermes and return a reply."""
     logger.info(f"Hermes message: channel={req.channel} content={req.content[:80]}... images={len(req.images) if req.images else 0}")
     verify_key(x_api_key)
+
+    # Server-side rate limiting
+    try:
+        from pathlib import Path
+        password = Path("~/.redis-password").expanduser().read_text().strip()
+        import redis
+        r_client = redis.Redis(
+            host=os.environ.get("COPPERMIND_REDIS_HOST", "100.64.219.124"),
+            port=6379, password=password, decode_responses=True,
+            socket_timeout=2, socket_connect_timeout=2,
+        )
+        allowed, retry_after = _check_server_rate_limit(r_client)
+        if not allowed:
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Rate limit exceeded"},
+                headers={"Retry-After": str(retry_after)},
+            )
+    except Exception as e:
+        logger.warning(f"Rate limit setup failed (allowing): {e}")
 
     # Validate images if present
     images = None

--- a/hermes.py
+++ b/hermes.py
@@ -150,6 +150,10 @@ def process_message(content: str, channel: str, model_override: Optional[str], m
     _store_turn(mem, "user", store_content)
     _store_turn(mem, "assistant", reply)
 
+    # Cache image description as a memory
+    if images:
+        _cache_image_description(reply, mem)
+
     return {
         "reply": reply,
         "model_used": model_key,
@@ -283,6 +287,21 @@ def _detect_intent(content: str, mem) -> Tuple[Optional[str], Optional[str]]:
         except Exception as e:
             return "status", f"Status check failed: {e}"
 
+    # /clear — reset conversation history
+    if stripped.lower() == "/clear":
+        try:
+            conn = mem.learning.postgres_store._get_conn()
+            with conn.cursor() as cur:
+                cur.execute("""
+                    DELETE FROM conversation_context
+                    WHERE agent_name = %s AND project = 'hermes'
+                """, (mem.agent_name,))
+            conn.commit()
+            return "clear", "Conversation cleared. Starting fresh."
+        except Exception as e:
+            logger.error(f"Failed to clear conversation: {e}")
+            return "clear", f"Failed to clear: {e}"
+
     return None, None
 
 
@@ -376,6 +395,7 @@ def _build_system_prompt(context: str, channel: str) -> str:
         "/tasks — list tasks\n"
         "/task <title> — add a task\n"
         "/status — check budget and model info\n"
+        "/clear — reset conversation history\n"
         "/sonnet or /opus — use a more powerful model for this message\n"
     )
 
@@ -488,8 +508,40 @@ def _record_cost(cost_usd: float, model: str):
         model_key = f"hermes:cost:{today}:{model}"
         r.incrbyfloat(model_key, cost_usd)
         r.expire(model_key, 172800)
+
+        # Message count for daily summary
+        count_key = f"hermes:msg_count:{today}"
+        r.incr(count_key)
+        r.expire(count_key, 172800)
     except Exception as e:
         logger.warning(f"Failed to record cost: {e}")
+
+
+def _cache_image_description(reply, mem):
+    """Cache a brief description of an image Ben sent, as a memory ember."""
+    try:
+        desc = reply[:200].strip()
+        last_period = desc.rfind(". ")
+        if last_period > 50:
+            desc = desc[:last_period + 1]
+        today = date.today().isoformat()
+        content = f"Photo sent by Ben via iMessage on {today}. Contents: {desc}"
+        mem.learning.postgres_store.store_knowledge(
+            agent_name=mem.agent_name,
+            category="fact",
+            content=content,
+            source="hermes_vision",
+            confidence=0.8,
+            learning_intensity="routine",
+            source_type="observation",
+            source_confidence=0.9,
+            memory_type="spark",
+            metadata={"capture_source": "hermes_vision", "date": today},
+            skip_quality_gates=True,
+        )
+        logger.info(f"Cached image description: {content[:80]}...")
+    except Exception as e:
+        logger.warning(f"Failed to cache image description: {e}")
 
 
 def send_imessage_proactive(recipient: str, text: str) -> bool:

--- a/hermes_daily_summary.py
+++ b/hermes_daily_summary.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Hermes Daily Cost Summary — sends cost report via iMessage if threshold exceeded.
+
+Designed to run as a systemd oneshot service triggered by a timer at 11pm CT.
+Idempotent: checks Redis guard key before sending.
+"""
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("hermes-daily-summary")
+
+# Config
+COST_THRESHOLD = float(os.environ.get("HERMES_COST_SUMMARY_THRESHOLD", "1.0"))
+REDIS_HOST = os.environ.get("COPPERMIND_REDIS_HOST", "100.64.219.124")
+REDIS_PORT = 6379
+SSH_HOST = os.environ.get("HERMES_SSH_HOST", "ben-mac")
+SEND_SCRIPT = os.environ.get("HERMES_SEND_SCRIPT", "/Users/benfinklea/bin/send_imessage.py")
+RECIPIENT = os.environ.get("HERMES_CHAT_IDENTIFIER", "coppermind@volacci.com")
+
+# Known models for cost breakdown
+KNOWN_MODELS = [
+    "claude-haiku-4-5-20251001",
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
+]
+MODEL_SHORT = {
+    "claude-haiku-4-5-20251001": "Haiku",
+    "claude-sonnet-4-6": "Sonnet",
+    "claude-opus-4-6": "Opus",
+}
+
+
+def get_redis():
+    import redis
+    password = Path("~/.redis-password").expanduser().read_text().strip()
+    return redis.Redis(
+        host=REDIS_HOST, port=REDIS_PORT,
+        password=password, decode_responses=True,
+        socket_timeout=5, socket_connect_timeout=5,
+    )
+
+
+def send_imessage(text: str) -> bool:
+    """Send iMessage via SSH to Mac."""
+    payload = json.dumps({"recipient": RECIPIENT, "text": text})
+    try:
+        result = subprocess.run(
+            [
+                "ssh",
+                "-o", "ConnectTimeout=10",
+                "-o", "ServerAliveInterval=5",
+                "-o", "ServerAliveCountMax=3",
+                SSH_HOST,
+                "python3", SEND_SCRIPT,
+            ],
+            input=payload.encode("utf-8"),
+            capture_output=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            logger.info(f"iMessage sent: {text[:80]}...")
+            return True
+        stderr = result.stderr.decode("utf-8", errors="replace")
+        logger.error(f"iMessage send failed: {stderr}")
+        return False
+    except subprocess.TimeoutExpired:
+        logger.error("SSH timed out (Mac may be asleep)")
+        return False
+    except Exception as e:
+        logger.error(f"Failed to send iMessage: {e}")
+        return False
+
+
+def main():
+    today = date.today().isoformat()
+    r = get_redis()
+
+    # Idempotency guard
+    guard_key = f"hermes:summary_sent:{today}"
+    if r.get(guard_key):
+        logger.info(f"Summary already sent for {today}")
+        return
+
+    # Get total cost
+    total_cost = float(r.get(f"hermes:cost:{today}") or 0)
+
+    # Check threshold
+    if total_cost < COST_THRESHOLD:
+        logger.info(f"Cost ${total_cost:.2f} < threshold ${COST_THRESHOLD:.2f} — skipping")
+        return
+
+    # Get message count
+    msg_count = int(r.get(f"hermes:msg_count:{today}") or 0)
+
+    # Get per-model breakdown
+    breakdown_lines = []
+    for model_id in KNOWN_MODELS:
+        model_cost = float(r.get(f"hermes:cost:{today}:{model_id}") or 0)
+        if model_cost > 0:
+            short_name = MODEL_SHORT.get(model_id, model_id)
+            breakdown_lines.append(f"- {short_name}: ${model_cost:.2f}")
+
+    # Format message
+    lines = [
+        "Coppermind> Daily summary",
+        f"Messages: {msg_count}",
+        f"Cost: ${total_cost:.2f}",
+    ]
+    lines.extend(breakdown_lines)
+    message = "\n".join(lines)
+
+    # Send
+    if send_imessage(message):
+        # Set idempotency guard (48h TTL)
+        r.set(guard_key, "1", ex=172800)
+        logger.info("Daily summary sent successfully")
+    else:
+        logger.error("Failed to send daily summary")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **Feature 1**: /clear command to reset conversation history
- **Feature 2**: Daily cost summary script (only if > $1) with systemd timer at 11pm CT
- **Feature 5**: Image description caching as Coppermind sparks for future recall
- **Infrastructure**: Server-side rate limiting (30/min) in capture.py with Redis sliding window

## Test plan
- [x] /clear returns Conversation cleared. Starting fresh.
- [x] Server-side rate limit: Redis counter incrementing correctly
- [x] Health check passes after restart
- [ ] Send photo then ask what was in that photo? retrieves cached description
- [ ] Daily summary: cost > $1 sends iMessage; cost < $1 exits quietly
- [ ] Timer: systemctl list-timers shows next run at 11pm CT

Generated with [Claude Code](https://claude.ai/code)